### PR TITLE
[trace-agent] Updates the message structure between 'api' and 'agent'

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -383,14 +383,16 @@ func (r *HTTPReceiver) tagStats(v Version, header http.Header) *info.TagStats {
 	})
 }
 
-func decodeTraces(v Version, req *http.Request) (pb.Traces, error) {
+func decodeTracerPayload(v Version, req *http.Request) (*pb.TracerPayload, error) {
 	switch v {
 	case v01:
 		var spans []pb.Span
 		if err := json.NewDecoder(req.Body).Decode(&spans); err != nil {
 			return nil, err
 		}
-		return tracesFromSpans(spans), nil
+		return &pb.TracerPayload{
+			Chunks: traceChunksFromSpans(spans),
+		}, nil
 	case v05:
 		buf := getBuffer()
 		defer putBuffer(buf)
@@ -398,14 +400,20 @@ func decodeTraces(v Version, req *http.Request) (pb.Traces, error) {
 			return nil, err
 		}
 		var traces pb.Traces
-		err := traces.UnmarshalMsgDictionary(buf.Bytes())
-		return traces, err
+		if err := traces.UnmarshalMsgDictionary(buf.Bytes()); err != nil {
+			return nil, err
+		}
+		return &pb.TracerPayload{
+			Chunks: traceChunksFromTraces(traces),
+		}, nil
 	default:
 		var traces pb.Traces
 		if err := decodeRequest(req, &traces); err != nil {
 			return nil, err
 		}
-		return traces, nil
+		return &pb.TracerPayload{
+			Chunks: traceChunksFromTraces(traces),
+		}, nil
 	}
 }
 
@@ -518,7 +526,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		return
 	}
 	start := time.Now()
-	traces, err := decodeTraces(v, req)
+	tracerPayload, err := decodeTracerPayload(v, req)
 	defer func(err error) {
 		tags := append(ts.AsTags(), fmt.Sprintf("success:%v", err == nil))
 		metrics.Histogram("datadog.trace_agent.receiver.serve_traces_ms", float64(time.Since(start))/float64(time.Millisecond), tags, 1)
@@ -545,14 +553,14 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		metrics.Histogram("datadog.trace_agent.receiver.rate_response_bytes", float64(n), tags, 1)
 	}
 
-	atomic.AddInt64(&ts.TracesReceived, int64(len(traces)))
+	atomic.AddInt64(&ts.TracesReceived, int64(len(tracerPayload.Chunks)))
 	atomic.AddInt64(&ts.TracesBytes, req.Body.(*apiutil.LimitedReader).Count)
 	atomic.AddInt64(&ts.PayloadAccepted, 1)
 
 	cid := req.Header.Get(headerContainerID)
 	payload := &Payload{
 		Source:                 ts,
-		Traces:                 traces,
+		TracerPayload:          tracerPayload,
 		ContainerID:            cid,
 		ContainerTags:          getContainerTags(cid),
 		ClientComputedTopLevel: req.Header.Get(headerComputedTopLevel) != "",
@@ -609,8 +617,8 @@ type Payload struct {
 	// trace (e.g. K8S pod, Docker image, ECS, etc). They are of the type "k1:v1,k2:v2".
 	ContainerTags string
 
-	// Traces contains all the traces received in the payload
-	Traces pb.Traces
+	// TracerPayload is a payload from the tracer
+	TracerPayload *pb.TracerPayload
 
 	// ClientComputedTopLevel specifies that the client has already marked top-level
 	// spans.
@@ -782,17 +790,30 @@ func decodeRequest(req *http.Request, dest *pb.Traces) error {
 	}
 }
 
-func tracesFromSpans(spans []pb.Span) pb.Traces {
-	traces := pb.Traces{}
+func traceChunksFromSpans(spans []pb.Span) []*pb.TraceChunk {
+	traceChunks := []*pb.TraceChunk{}
 	byID := make(map[uint64][]*pb.Span)
 	for _, s := range spans {
 		byID[s.TraceID] = append(byID[s.TraceID], &s)
 	}
 	for _, t := range byID {
-		traces = append(traces, t)
+		traceChunks = append(traceChunks, &pb.TraceChunk{
+			Spans: t,
+		})
 	}
 
-	return traces
+	return traceChunks
+}
+
+func traceChunksFromTraces(traces pb.Traces) []*pb.TraceChunk {
+	traceChunks := make([]*pb.TraceChunk, 0, len(traces))
+	for _, trace := range traces {
+		traceChunks = append(traceChunks, &pb.TraceChunk{
+			Spans: trace,
+		})
+	}
+
+	return traceChunks
 }
 
 // getContainerTag returns container and orchestrator tags belonging to containerID. If containerID

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -190,8 +190,8 @@ func TestLegacyReceiver(t *testing.T) {
 			// now we should be able to read the trace data
 			select {
 			case p := <-tc.r.out:
-				assert.Len(p.Traces, 1)
-				rt := p.Traces[0]
+				assert.Len(p.TracerPayload.Chunks, 1)
+				rt := p.TracerPayload.Chunks[0].Spans
 				assert.Len(rt, 1)
 				span := rt[0]
 				assert.Equal(uint64(42), span.TraceID)
@@ -255,7 +255,7 @@ func TestReceiverJSONDecoder(t *testing.T) {
 			// now we should be able to read the trace data
 			select {
 			case p := <-tc.r.out:
-				rt := p.Traces[0]
+				rt := p.TracerPayload.Chunks[0].Spans
 				assert.Len(rt, 1)
 				span := rt[0]
 				assert.Equal(uint64(42), span.TraceID)
@@ -322,7 +322,7 @@ func TestReceiverMsgpackDecoder(t *testing.T) {
 				// now we should be able to read the trace data
 				select {
 				case p := <-tc.r.out:
-					rt := p.Traces[0]
+					rt := p.TracerPayload.Chunks[0].Spans
 					assert.Len(rt, 1)
 					span := rt[0]
 					assert.Equal(uint64(42), span.TraceID)
@@ -345,7 +345,7 @@ func TestReceiverMsgpackDecoder(t *testing.T) {
 				// now we should be able to read the trace data
 				select {
 				case p := <-tc.r.out:
-					rt := p.Traces[0]
+					rt := p.TracerPayload.Chunks[0].Spans
 					assert.Len(rt, 1)
 					span := rt[0]
 					assert.Equal(uint64(42), span.TraceID)
@@ -497,51 +497,55 @@ func TestDecodeV05(t *testing.T) {
 	assert.NoError(err)
 	req, err := http.NewRequest("POST", "/v0.5/traces", bytes.NewReader(b))
 	assert.NoError(err)
-	traces, err := decodeTraces(v05, req)
+	tracerPayload, err := decodeTracerPayload(v05, req)
 	assert.NoError(err)
-	assert.EqualValues(traces, pb.Traces{
-		{
+	assert.EqualValues(tracerPayload, &pb.TracerPayload{
+		Chunks: []*pb.TraceChunk{
 			{
-				Service:  "Service",
-				Name:     "Name",
-				Resource: "Resource",
-				TraceID:  1,
-				SpanID:   2,
-				ParentID: 3,
-				Start:    123,
-				Duration: 456,
-				Error:    1,
-				Meta:     map[string]string{"A": "B"},
-				Metrics:  map[string]float64{"X": 1.2},
-				Type:     "sql",
-			},
-			{
-				Service:  "Service2",
-				Name:     "Name2",
-				Resource: "Resource2",
-				TraceID:  2,
-				SpanID:   3,
-				ParentID: 3,
-				Start:    789,
-				Duration: 456,
-				Error:    0,
-				Meta:     map[string]string{"c": "d"},
-				Metrics:  map[string]float64{"y": 1.4},
-				Type:     "sql",
-			},
-			{
-				Service:  "Service2",
-				Name:     "Name2",
-				Resource: "Resource2",
-				TraceID:  2,
-				SpanID:   3,
-				ParentID: 3,
-				Start:    789,
-				Duration: 456,
-				Error:    0,
-				Meta:     map[string]string{"c": "d"},
-				Metrics:  nil,
-				Type:     "sql",
+				Spans: []*pb.Span{
+					{
+						Service:  "Service",
+						Name:     "Name",
+						Resource: "Resource",
+						TraceID:  1,
+						SpanID:   2,
+						ParentID: 3,
+						Start:    123,
+						Duration: 456,
+						Error:    1,
+						Meta:     map[string]string{"A": "B"},
+						Metrics:  map[string]float64{"X": 1.2},
+						Type:     "sql",
+					},
+					{
+						Service:  "Service2",
+						Name:     "Name2",
+						Resource: "Resource2",
+						TraceID:  2,
+						SpanID:   3,
+						ParentID: 3,
+						Start:    789,
+						Duration: 456,
+						Error:    0,
+						Meta:     map[string]string{"c": "d"},
+						Metrics:  map[string]float64{"y": 1.4},
+						Type:     "sql",
+					},
+					{
+						Service:  "Service2",
+						Name:     "Name2",
+						Resource: "Resource2",
+						TraceID:  2,
+						SpanID:   3,
+						ParentID: 3,
+						Start:    789,
+						Duration: 456,
+						Error:    0,
+						Meta:     map[string]string{"c": "d"},
+						Metrics:  nil,
+						Type:     "sql",
+					},
+				},
 			},
 		},
 	})

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -174,7 +174,7 @@ func TestOTLPReceiver(t *testing.T) {
 			case p := <-out:
 				assert.Equal(t, "go", p.Source.Lang)
 				assert.Equal(t, "opentelemetry_grpc_v1", p.Source.EndpointVersion)
-				assert.Len(t, p.Traces, 1)
+				assert.Len(t, p.TracerPayload.Chunks, 1)
 				ps[i] = p
 			case <-timeout:
 				t.Fatal("timed out")

--- a/pkg/trace/pb/trace.go
+++ b/pkg/trace/pb/trace.go
@@ -13,3 +13,15 @@ type Trace []*Span
 
 // Traces is a list of traces. This model matters as this is what we unpack from msgp.
 type Traces []Trace
+
+// TraceChunk is a collection of spans with the same trace ID and their baggage
+type TraceChunk struct {
+	Priority int32
+	Spans    []*Span
+}
+
+// TracerPayload is a collection of trace chunks and tracer tags
+type TracerPayload struct {
+	Tags   map[string]string
+	Chunks []*TraceChunk
+}

--- a/pkg/trace/test/testutil/trace.go
+++ b/pkg/trace/test/testutil/trace.go
@@ -86,6 +86,14 @@ func RandomTrace(maxLevels, maxSpans int) pb.Trace {
 	return t
 }
 
+// RandomTraceChunk generates a random trace chunk with a depth from 1 to
+// maxLevels of spans. Each level has at most maxSpans items.
+func RandomTraceChunk(maxLevels, maxSpans int) *pb.TraceChunk {
+	return &pb.TraceChunk{
+		Spans: RandomTrace(maxLevels, maxLevels),
+	}
+}
+
 // GetTestTraces returns a []Trace that is composed by ``traceN`` number
 // of traces, each one composed by ``size`` number of spans.
 func GetTestTraces(traceN, size int, realisticIDs bool) pb.Traces {
@@ -114,4 +122,17 @@ func GetTestTraces(traceN, size int, realisticIDs bool) pb.Traces {
 		traces = append(traces, trace)
 	}
 	return traces
+}
+
+// GetTestTraceChunks returns a []TraceChunk that is composed by ``traceN`` number
+// of traces, each one composed by ``size`` number of spans.
+func GetTestTraceChunks(traceN, size int, realisticIDs bool) []*pb.TraceChunk {
+	traces := GetTestTraces(traceN, size, realisticIDs)
+	traceChunks := make([]*pb.TraceChunk, 0, len(traces))
+	for _, trace := range traces {
+		traceChunks = append(traceChunks, &pb.TraceChunk{
+			Spans: trace,
+		})
+	}
+	return traceChunks
 }

--- a/pkg/trace/traceutil/trace.go
+++ b/pkg/trace/traceutil/trace.go
@@ -65,9 +65,9 @@ func GetRoot(t pb.Trace) *pb.Span {
 
 // APITrace returns an APITrace from t, as required by the Datadog API.
 // It also returns an estimated size in bytes.
-func APITrace(t pb.Trace) *pb.APITrace {
+func APITrace(t *pb.TraceChunk) *pb.APITrace {
 	earliest, latest := int64(math.MaxInt64), int64(0)
-	for _, s := range t {
+	for _, s := range t.Spans {
 		start := s.Start
 		if start < earliest {
 			earliest = start
@@ -78,8 +78,8 @@ func APITrace(t pb.Trace) *pb.APITrace {
 		}
 	}
 	return &pb.APITrace{
-		TraceID:   t[0].TraceID,
-		Spans:     t,
+		TraceID:   t.Spans[0].TraceID,
+		Spans:     t.Spans,
 		StartTime: earliest,
 		EndTime:   latest,
 	}

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -115,12 +115,12 @@ func useFlushThreshold(n int) func() {
 // randomSampledSpans returns a set of spans sampled spans and events events.
 func randomSampledSpans(spans, events int) *SampledSpans {
 	realisticIDs := true
-	trace := testutil.GetTestTraces(1, spans, realisticIDs)[0]
+	traceChunk := testutil.GetTestTraceChunks(1, spans, realisticIDs)[0]
 	return &SampledSpans{
-		Traces:    []*pb.APITrace{traceutil.APITrace(trace)},
-		Events:    trace[:events],
-		Size:      trace.Msgsize() + pb.Trace(trace[:events]).Msgsize(),
-		SpanCount: int64(len(trace)),
+		Traces:    []*pb.APITrace{traceutil.APITrace(traceChunk)},
+		Events:    traceChunk.Spans[:events],
+		Size:      pb.Trace(traceChunk.Spans).Msgsize() + pb.Trace(traceChunk.Spans[:events]).Msgsize(),
+		SpanCount: int64(len(traceChunk.Spans)),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR updates the message structure between `api` and `agent`.

Old message:
```
[][]*Span
```

New message:
```
TracerPayload {
    Tags map[string]string
    Chunks {
        priority // a baggage
        []*Span
    }
}
```

### Motivation

We would like receive the following information from the tracer to enrich our features.
- tracer tags
- trace level tags

To do that, we need to receive two level of structured data from tracer instead of `[][]*Span`.

### Additional Notes

This PR doesn't contain any logical change. But, there will be 2 more PRs after this one gets merged.
- A new endpoint in `trace-agent` that receives structured payload from traces
- A new trace payload format we are going to use in future intake

### Describe how to test your changes

As this PR doesn't introduce a new feature,
- [ ] making sure it didn't break anything
- [ ] making sure the performance wasn't degraded

in the usual environment should enough for the test.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
